### PR TITLE
feat: region input from env

### DIFF
--- a/pkg/provider/provider_test.go
+++ b/pkg/provider/provider_test.go
@@ -15,10 +15,11 @@ import (
 var (
 	accessKey = os.Getenv("AWS_ACCESS_KEY_ID")
 	secretKey = os.Getenv("AWS_SECRET_ACCESS_KEY")
+	region    = os.Getenv("AWS_DEFAULT_REGION")
 
 	awsProvider   = &AWSProvider{}
 	targetOptions = &types.TargetOptions{
-		Region:          "us-east-1",
+		Region:          region,
 		ImageId:         "ami-04a81a99f5ec58529",
 		InstanceType:    "t2.micro",
 		DeviceName:      "/dev/sda1",

--- a/pkg/types/targets.go
+++ b/pkg/types/targets.go
@@ -24,8 +24,9 @@ func GetTargetManifest() *provider.ProviderTargetManifest {
 		"Region": provider.ProviderTargetProperty{
 			Type:         provider.ProviderTargetPropertyTypeString,
 			DefaultValue: "us-east-1",
-			Description: "The geographic area where AWS resourced are hosted. Default is us-east-1.\n" +
-				"List of available regions:\nhttps://docs.aws.amazon.com/general/latest/gr/rande.html",
+			Description: "The geographic area where AWS resourced are hosted. List of available regions:\n" +
+				"https://docs.aws.amazon.com/general/latest/gr/rande.html\n" +
+				"Leave blank if you've set the AWS_DEFAULT_REGION environment variable, or enter your region here.",
 		},
 		"Instance Type": provider.ProviderTargetProperty{
 			Type:         provider.ProviderTargetPropertyTypeString,
@@ -94,12 +95,23 @@ func ParseTargetOptions(optionsJson string) (*TargetOptions, error) {
 		}
 	}
 
+	if targetOptions.Region == "" {
+		region, ok := os.LookupEnv("AWS_DEFAULT_REGION")
+		if ok {
+			targetOptions.Region = region
+		}
+	}
+
 	if targetOptions.AccessKeyId == "" {
 		return nil, fmt.Errorf("access key id not set in env/target options")
 	}
 
 	if targetOptions.SecretAccessKey == "" {
 		return nil, fmt.Errorf("secret access key not set in env/target options")
+	}
+
+	if targetOptions.Region == "" {
+		return nil, fmt.Errorf("region not set in env/target options")
 	}
 
 	return &targetOptions, nil

--- a/pkg/types/targets_test.go
+++ b/pkg/types/targets_test.go
@@ -66,6 +66,7 @@ func TestParseTargetOptions(t *testing.T) {
 			envVars: map[string]string{
 				"AWS_ACCESS_KEY_ID":     "accessKeyID",
 				"AWS_SECRET_ACCESS_KEY": "secretAccessKey",
+				"AWS_DEFAULT_REGION":    "us-east-1",
 			},
 			want: &TargetOptions{
 				Region:          "us-east-1",


### PR DESCRIPTION
# Get region input from env

## Description

Loads AWS_DEFAULT_REGION from the environment and updates the `daytona target set` view accordingly

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Notes
When testing, remove the prefilled region when setting the target through Daytona
