### PR TITLE
refactor: add container registires as an array input

### DIFF
--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -237,14 +237,13 @@ func (a *AWSProvider) CreateWorkspace(workspaceReq *provider.WorkspaceRequest) (
 	defer sshClient.Close()
 
 	return new(util.Empty), dockerClient.CreateWorkspace(&docker.CreateWorkspaceOptions{
-		Workspace:                workspaceReq.Workspace,
-		WorkspaceDir:             getWorkspaceDir(workspaceReq),
-		ContainerRegistry:        workspaceReq.ContainerRegistry,
-		BuilderImage:             workspaceReq.BuilderImage,
-		BuilderContainerRegistry: workspaceReq.BuilderContainerRegistry,
-		LogWriter:                logWriter,
-		Gpc:                      workspaceReq.GitProviderConfig,
-		SshClient:                sshClient,
+		Workspace:           workspaceReq.Workspace,
+		WorkspaceDir:        getWorkspaceDir(workspaceReq),
+		ContainerRegistries: workspaceReq.ContainerRegistries,
+		BuilderImage:        workspaceReq.BuilderImage,
+		LogWriter:           logWriter,
+		Gpc:                 workspaceReq.GitProviderConfig,
+		SshClient:           sshClient,
 	})
 }
 
@@ -272,14 +271,13 @@ func (a *AWSProvider) StartWorkspace(workspaceReq *provider.WorkspaceRequest) (*
 	defer sshClient.Close()
 
 	return new(util.Empty), dockerClient.StartWorkspace(&docker.CreateWorkspaceOptions{
-		Workspace:                workspaceReq.Workspace,
-		WorkspaceDir:             getWorkspaceDir(workspaceReq),
-		ContainerRegistry:        workspaceReq.ContainerRegistry,
-		BuilderImage:             workspaceReq.BuilderImage,
-		BuilderContainerRegistry: workspaceReq.BuilderContainerRegistry,
-		LogWriter:                logWriter,
-		Gpc:                      workspaceReq.GitProviderConfig,
-		SshClient:                sshClient,
+		Workspace:           workspaceReq.Workspace,
+		WorkspaceDir:        getWorkspaceDir(workspaceReq),
+		ContainerRegistries: workspaceReq.ContainerRegistries,
+		BuilderImage:        workspaceReq.BuilderImage,
+		LogWriter:           logWriter,
+		Gpc:                 workspaceReq.GitProviderConfig,
+		SshClient:           sshClient,
 	}, *a.DaytonaDownloadUrl)
 }
 


### PR DESCRIPTION
# Add container registires as an array input

## Description

In this PR provider receives container registries as an array instead of receiving each container registry separately.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation